### PR TITLE
[Breaking] Fix generic result view tag types

### DIFF
--- a/src/lib/config/SearchConfig.ts
+++ b/src/lib/config/SearchConfig.ts
@@ -1,4 +1,4 @@
-import { FilterType, FilterValueValue, RequestState, SearchFieldConfiguration, SortOption } from "@elastic/search-ui"
+import { FieldValue, FilterType, RequestState, SearchFieldConfiguration, SortOption } from "@elastic/search-ui"
 import { ReactNode } from "react"
 
 export interface CoreFacetConfig {
@@ -32,7 +32,7 @@ export interface CoreFacetConfig {
      *
      * @param value
      */
-    singleValueMapper?: (value: FilterValueValue) => ReactNode
+    singleValueMapper?: (value: FieldValue) => ReactNode
 
     /**
      * Not properly implemented at the moment. Use with caution.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,7 +26,7 @@ export function prettyPrintURL(url: string) {
 }
 
 export function autoUnwrap<E>(item?: E | { raw?: E }) {
-    if (!item) {
+    if (item === undefined || item === null) {
         return undefined
     } else if (typeof item === "object" && "raw" in item) {
         return item.raw

--- a/src/stories/Others/GenericResultView.stories.tsx
+++ b/src/stories/Others/GenericResultView.stories.tsx
@@ -123,14 +123,14 @@ export const Full: Story = {
             {
                 icon: <GlobeIcon className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                 field: "hadPrimarySource",
-                singleValueMapper: prettyPrintURL,
+                singleValueMapper: (v) => prettyPrintURL(v + ""),
                 label: "Primary Source",
                 clickBehavior: "follow-url"
             },
             {
                 icon: <ScaleIcon className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                 field: "licenseURL",
-                singleValueMapper: prettyPrintURL,
+                singleValueMapper: (v) => prettyPrintURL(v + ""),
                 label: "License URL",
                 clickBehavior: "follow-url"
             },
@@ -161,7 +161,7 @@ export const Full: Story = {
             },
             {
                 field: "stringArrayTest",
-                singleValueMapper: (v) => v.toUpperCase()
+                singleValueMapper: (v) => (v + "").toUpperCase()
             }
         ]
     }

--- a/src/stories/ReactSearchComponent.stories.tsx
+++ b/src/stories/ReactSearchComponent.stories.tsx
@@ -159,7 +159,7 @@ export const GenericResultRenderer: Story = {
                         icon: <UserIcon className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         label: "Contact",
                         field: "contact",
-                        singleValueMapper: (v) => <OrcidDisplay orcid={v} />,
+                        singleValueMapper: (v) => <OrcidDisplay orcid={v + ""} />,
                         clickBehavior: "follow-url"
                     },
                     {
@@ -170,7 +170,7 @@ export const GenericResultRenderer: Story = {
                     {
                         icon: <GlobeIcon className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         field: "hadPrimarySource",
-                        singleValueMapper: (v) => mapPrimarySource(v),
+                        singleValueMapper: (v) => mapPrimarySource(v + ""),
                         label: "Source",
                         onClick: (e) =>
                             "innerText" in e.target &&
@@ -180,7 +180,7 @@ export const GenericResultRenderer: Story = {
                     {
                         icon: <ScaleIcon className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         field: "licenseURL",
-                        singleValueMapper: (v) => <PidNameDisplay pid={v} />,
+                        singleValueMapper: (v) => <PidNameDisplay pid={v + ""} />,
                         label: "License URL",
                         clickBehavior: "follow-url"
                     },
@@ -194,13 +194,13 @@ export const GenericResultRenderer: Story = {
                         icon: <Microscope className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         label: "NMR Method",
                         field: "NMR_Method",
-                        singleValueMapper: (v) => <PidNameDisplay pid={v} />
+                        singleValueMapper: (v) => <PidNameDisplay pid={v + ""} />
                     },
                     {
                         icon: <FlaskConical className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         label: "NMR Solvent",
                         field: "NMR_Solvent",
-                        singleValueMapper: (v) => <PidNameDisplay pid={v} />
+                        singleValueMapper: (v) => <PidNameDisplay pid={v + ""} />
                     },
                     {
                         icon: <AudioLines className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
@@ -211,7 +211,7 @@ export const GenericResultRenderer: Story = {
                         icon: <CircleDot className="rfs-shrink-0 rfs-size-4 rfs-mr-2" />,
                         label: "Acquisition Nucleus",
                         field: "Acquisition_Nucleus",
-                        singleValueMapper: (v) => <PidNameDisplay pid={v} />
+                        singleValueMapper: (v) => <PidNameDisplay pid={v + ""} />
                     }
                 ]}
                 titleField="name"


### PR DESCRIPTION
Closes #21 

Changes types for `valueMapper` and `singleValueMapper` to `FieldValue` (which resolves to `string | number | boolean | Array<string | number | boolean>`). Previously, it was only `string | string[]`, so this is a breaking change

Also fixed an issue where array tags all had the same "Copied" animation when clicking only one of them.